### PR TITLE
empty incorrect destructive command

### DIFF
--- a/src/Migration/Migration1689245968RenameCofingurationKeys.php
+++ b/src/Migration/Migration1689245968RenameCofingurationKeys.php
@@ -25,11 +25,5 @@ SQL;
 
     public function updateDestructive(Connection $connection): void
     {
-        $query = <<<SQL
-            UPDATE `system_config` 
-            SET `configuration_key` = REPLACE(`configuration_key`, 'config', 'settings') 
-            WHERE `configuration_key` LIKE 'PaynlPaymentShopware6.config%';
-SQL;
-        $connection->executeStatement($query);
     }
 }


### PR DESCRIPTION
We've ran the migration destructive command on the latest plugin version for one of our customers.
But it 'broke' the plugin in a way. It renamed the new configuration_key 'settings' back to 'config' which the plugin didn't used anymore.
Therefor I think that the destructive command should be empty.