### PR TITLE
[S6PD-129] Improve headless support

### DIFF
--- a/src/Components/Payment/InitiatePaymentAction.php
+++ b/src/Components/Payment/InitiatePaymentAction.php
@@ -23,40 +23,34 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Checkout\Payment\Exception\AsyncPaymentProcessException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Throwable;
 
 class InitiatePaymentAction
 {
-    private UrlGeneratorInterface $router;
-    private PaymentUrlBuilder $paymentUrlBuilder;
     private Api $payAPI;
     private LoggerInterface $logger;
     private PaymentMethodTerminalService $paymentMethodTerminalService;
     private ProcessingHelper $processingHelper;
     private PluginHelper $pluginHelper;
     private RequestDataBagHelper $requestDataBagHelper;
+    private PaymentUrlBuilder $paymentUrlBuilder;
     private TranslatorInterface $translator;
     private RequestStack $requestStack;
     private string $shopwareVersion;
 
     public function __construct(
-        RouterInterface $router,
         Api $api,
         LoggerInterface $logger,
         PaymentMethodTerminalService $paymentMethodTerminalService,
         ProcessingHelper $processingHelper,
         PluginHelper $pluginHelper,
         RequestDataBagHelper $requestDataBagHelper,
+        PaymentUrlBuilder $paymentUrlBuilder,
         TranslatorInterface $translator,
         RequestStack $requestStack,
-        string $shopwareVersion,
-        PaymentUrlBuilder $paymentUrlBuilder
+        string $shopwareVersion
     ) {
-        $this->router = $router;
-        $this->paymentUrlBuilder = $paymentUrlBuilder;
         $this->payAPI = $api;
         $this->logger = $logger;
         $this->paymentMethodTerminalService = $paymentMethodTerminalService;
@@ -65,6 +59,7 @@ class InitiatePaymentAction
         $this->requestDataBagHelper = $requestDataBagHelper;
         $this->translator = $translator;
         $this->requestStack = $requestStack;
+        $this->paymentUrlBuilder = $paymentUrlBuilder;
         $this->shopwareVersion = $shopwareVersion;
     }
 

--- a/src/Components/Payment/InitiatePaymentAction.php
+++ b/src/Components/Payment/InitiatePaymentAction.php
@@ -11,6 +11,7 @@ use PaynlPayment\Shopware6\Helper\PluginHelper;
 use PaynlPayment\Shopware6\Helper\ProcessingHelper;
 use PaynlPayment\Shopware6\Helper\RequestDataBagHelper;
 use PaynlPayment\Shopware6\Service\PaymentMethod\PaymentMethodTerminalService;
+use PaynlPayment\Shopware6\Service\Router\PaymentUrlBuilder;
 use PaynlPayment\Shopware6\ValueObjects\AdditionalTransactionInfo;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
@@ -30,6 +31,7 @@ use Throwable;
 class InitiatePaymentAction
 {
     private UrlGeneratorInterface $router;
+    private PaymentUrlBuilder $paymentUrlBuilder;
     private Api $payAPI;
     private LoggerInterface $logger;
     private PaymentMethodTerminalService $paymentMethodTerminalService;
@@ -50,9 +52,11 @@ class InitiatePaymentAction
         RequestDataBagHelper $requestDataBagHelper,
         TranslatorInterface $translator,
         RequestStack $requestStack,
-        string $shopwareVersion
+        string $shopwareVersion,
+        PaymentUrlBuilder $paymentUrlBuilder
     ) {
         $this->router = $router;
+        $this->paymentUrlBuilder = $paymentUrlBuilder;
         $this->payAPI = $api;
         $this->logger = $logger;
         $this->paymentMethodTerminalService = $paymentMethodTerminalService;
@@ -130,11 +134,12 @@ class InitiatePaymentAction
         SalesChannelContext $salesChannelContext
     ): string {
         $payTransactionId = '';
-        $exchangeUrl = $this->router->generate('frontend.PaynlPayment.notify', [], UrlGeneratorInterface::ABSOLUTE_URL);
+        $exchangeUrl = $this->paymentUrlBuilder->buildExchangeUrl();
 
-        $parameterUrl = parse_url($returnUrl)['query'];
-        $paymentToken = explode('=', $parameterUrl)[1];
-        $returnUrl = $this->router->generate('frontend.PaynlPayment.finalize-transaction', ['_sw_payment_token' => $paymentToken], UrlGeneratorInterface::ABSOLUTE_URL);
+        $parameterUrl = parse_url($returnUrl, PHP_URL_QUERY) ?? '';
+        parse_str($parameterUrl, $params);
+        $paymentToken = $params['_sw_payment_token'] ?? '';
+        $returnUrl = $this->paymentUrlBuilder->buildReturnUrl($paymentToken);
 
         $terminal = $this->getRequestTerminal();
 

--- a/src/Controller/Api/Notification/NotificationController.php
+++ b/src/Controller/Api/Notification/NotificationController.php
@@ -1,15 +1,15 @@
-<?php declare(strict_types=1);
+<?php
 
-namespace PaynlPayment\Shopware6\Controller\Storefront\Notification;
+declare(strict_types=1);
+
+namespace PaynlPayment\Shopware6\Controller\Api\Notification;
 
 use PaynlPayment\Shopware6\Service\Notification\NotificationFacade;
-use Shopware\Storefront\Controller\StorefrontController;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
 
-#[Route(defaults: ['_routeScope' => ['storefront'], 'csrf_protected' => false, 'auth_required' => true, 'auth_enabled' => true])]
-class NotificationController extends StorefrontController
+class NotificationController extends AbstractController
 {
     private NotificationFacade $notificationFacade;
 
@@ -18,7 +18,6 @@ class NotificationController extends StorefrontController
         $this->notificationFacade = $notificationFacade;
     }
 
-    #[Route('/PaynlPayment/notify', name: 'frontend.PaynlPayment.notify', options: ['seo' => false], methods: ['GET', 'POST'])]
     public function notify(Request $request): Response
     {
         $body = $this->notificationFacade->onNotify($request);

--- a/src/Controller/Api/Notification/NotificationController.php
+++ b/src/Controller/Api/Notification/NotificationController.php
@@ -8,7 +8,9 @@ use PaynlPayment\Shopware6\Service\Notification\NotificationFacade;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
 
+#[Route(path: '/api/paynl', defaults: ['_routeScope' => ['api'], 'auth_required' => false, 'auth_enabled' => false])]
 class NotificationController extends AbstractController
 {
     private NotificationFacade $notificationFacade;
@@ -18,6 +20,7 @@ class NotificationController extends AbstractController
         $this->notificationFacade = $notificationFacade;
     }
 
+    #[Route('/notify', name: 'api.PaynlPayment.notify', methods: ['GET', 'POST'])]
     public function notify(Request $request): Response
     {
         $body = $this->notificationFacade->onNotify($request);

--- a/src/Controller/Api/Payment/PaymentController.php
+++ b/src/Controller/Api/Payment/PaymentController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PaynlPayment\Shopware6\Controller\Api\Payment;
+
+use PaynlPayment\Shopware6\Service\Payment\PaymentFinalizeFacade;
+use Shopware\Core\Framework\Context;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class PaymentController extends AbstractController
+{
+    private PaymentFinalizeFacade $finalizeFacade;
+
+    public function __construct(PaymentFinalizeFacade $finalizeFacade)
+    {
+        $this->finalizeFacade = $finalizeFacade;
+    }
+
+    public function finalizeTransaction(Request $request, Context $context): Response
+    {
+        $result = $this->finalizeFacade->finalizeTransaction($request, $context);
+
+        return $result->getResponse();
+    }
+}

--- a/src/Controller/Api/Payment/PaymentController.php
+++ b/src/Controller/Api/Payment/PaymentController.php
@@ -9,7 +9,9 @@ use Shopware\Core\Framework\Context;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
 
+#[Route(path: '/api/paynl/payment', defaults: ['_routeScope' => ['api'], 'auth_required' => false, 'auth_enabled' => false])]
 class PaymentController extends AbstractController
 {
     private PaymentFinalizeFacade $finalizeFacade;
@@ -19,6 +21,7 @@ class PaymentController extends AbstractController
         $this->finalizeFacade = $finalizeFacade;
     }
 
+    #[Route('/finalize-transaction', name: 'api.PaynlPayment.finalize-transaction', methods: ['GET'])]
     public function finalizeTransaction(Request $request, Context $context): Response
     {
         $result = $this->finalizeFacade->finalizeTransaction($request, $context);

--- a/src/Controller/Storefront/Payment/PaymentController.php
+++ b/src/Controller/Storefront/Payment/PaymentController.php
@@ -2,20 +2,13 @@
 
 namespace PaynlPayment\Shopware6\Controller\Storefront\Payment;
 
-use PaynlPayment\Shopware6\Entity\PaynlTransactionEntity;
-use PaynlPayment\Shopware6\Exceptions\PaynlTransactionException;
 use PaynlPayment\Shopware6\Repository\OrderTransaction\OrderTransactionRepositoryInterface;
-use PaynlPayment\Shopware6\Repository\PaynlTransactions\PaynlTransactionsRepositoryInterface;
-use Psr\Log\LoggerInterface;
+use PaynlPayment\Shopware6\Service\Payment\PaymentFinalizeFacade;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\Checkout\Payment\Controller\PaymentController as ShopwarePaymentController;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route(defaults: ['_routeScope' => ['storefront'], 'csrf_protected' => false, 'auth_required' => false, 'auth_enabled' => false])]
@@ -24,80 +17,36 @@ class PaymentController extends AbstractController
     private const PAY_CUSTOM_FIELD = 'paynl';
     private const TRANSACTION_FINISH_URL = 'transactionFinishUrl';
 
-    private ShopwarePaymentController $paymentController;
-
-    private LoggerInterface $logger;
-
     private OrderTransactionRepositoryInterface $orderTransactionRepository;
 
-    private PaynlTransactionsRepositoryInterface $paynlTransactionRepository;
+    private PaymentFinalizeFacade $finalizeFacade;
 
     public function __construct(
-        ShopwarePaymentController $paymentController,
-        LoggerInterface $logger,
         OrderTransactionRepositoryInterface $orderTransactionRepository,
-        PaynlTransactionsRepositoryInterface $paynlTransactionRepository
+        PaymentFinalizeFacade $finalizeFacade
     ) {
-        $this->paymentController = $paymentController;
-        $this->logger = $logger;
         $this->orderTransactionRepository = $orderTransactionRepository;
-        $this->paynlTransactionRepository = $paynlTransactionRepository;
+        $this->finalizeFacade = $finalizeFacade;
     }
 
     #[Route('/PaynlPayment/finalize-transaction', name: 'frontend.PaynlPayment.finalize-transaction', options: ['seo' => false], methods: ['GET'])]
     public function finalizeTransaction(Request $request, SalesChannelContext $salesChannelContext): RedirectResponse
     {
-        $payOrderId = (string) $request->query->get('id');
+        $result = $this->finalizeFacade->finalizeTransaction($request, $salesChannelContext->getContext());
 
-        $criteria = (new Criteria());
-        $criteria->addFilter(new EqualsFilter('paynlTransactionId', $payOrderId));
-        $criteria->addAssociation('order');
-        $criteria->addAssociation('orderTransaction.stateMachineState');
-        $criteria->addAssociation('orderTransaction.order');
-
-        $context = $salesChannelContext->getContext();
-
-        /** @var PaynlTransactionEntity $payTransaction */
-        $payTransaction = $this->paynlTransactionRepository->search($criteria, $context)->first();
-
-        /** @var OrderTransactionEntity|null $orderTransaction */
-        $orderTransaction = $payTransaction->getOrderTransaction();
-
-        if ($orderTransaction === null) {
-            throw PaynlTransactionException::notFoundByPayTransactionError($payOrderId);
-        }
-        $order = $orderTransaction->getOrder();
-
-        if ($order === null) {
-            throw PaynlTransactionException::notFoundByPayTransactionError($orderTransaction->getId());
-        }
-
-        $orderId = $order->getId();
-
-        try {
-            $finalizeTransactionResponse = $this->paymentController->finalizeTransaction($request);
-
-            if ($finalizeTransactionResponse instanceof RedirectResponse) {
+        $orderTransaction = $result->getOrderTransaction();
+        if ($orderTransaction !== null) {
+            $response = $result->getResponse();
+            if ($response instanceof RedirectResponse) {
                 $this->saveOrderTransactionFinishUrl(
                     $orderTransaction,
-                    $finalizeTransactionResponse->getTargetUrl(),
+                    $response->getTargetUrl(),
                     $salesChannelContext
                 );
-
-                return $finalizeTransactionResponse;
             }
-        } catch (HttpException $httpException) {
-            $this->logger->error(
-                '{message}. Redirecting to confirm page.',
-                ['message' => $httpException->getMessage(), 'error' => $httpException]
-            );
         }
 
-        if ($this->getOrderTransactionFinishUrl($orderTransaction)) {
-            return $this->redirect($this->getOrderTransactionFinishUrl($orderTransaction));
-        }
-
-        return $this->redirectToRoute('frontend.checkout.finish.page', ['orderId' => $orderId]);
+        return $result->getResponse();
     }
 
     private function saveOrderTransactionFinishUrl(OrderTransactionEntity $orderTransaction, string $finishUrl, SalesChannelContext $salesChannelContext): void

--- a/src/Resources/config/routes.xml
+++ b/src/Resources/config/routes.xml
@@ -5,22 +5,4 @@
         https://symfony.com/schema/routing/routing-1.0.xsd">
 
     <import resource="../../**/Controller/**/*Controller.php" type="attribute" />
-
-    <route id="api.PaynlPayment.finalize-transaction"
-           path="/api/paynl/payment/finalize-transaction"
-           methods="GET">
-        <default key="_controller">PaynlPayment\Shopware6\Controller\Api\Payment\PaymentController::finalizeTransaction</default>
-        <default key="_routeScope"><list><string>api</string></list></default>
-        <default key="auth_required"><bool>false</bool></default>
-        <default key="auth_enabled"><bool>false</bool></default>
-    </route>
-
-    <route id="api.PaynlPayment.notify"
-           path="/api/paynl/notify"
-           methods="GET|POST">
-        <default key="_controller">PaynlPayment\Shopware6\Controller\Api\Notification\NotificationController::notify</default>
-        <default key="_routeScope"><list><string>api</string></list></default>
-        <default key="auth_required"><bool>false</bool></default>
-        <default key="auth_enabled"><bool>false</bool></default>
-    </route>
 </routes>

--- a/src/Resources/config/routes.xml
+++ b/src/Resources/config/routes.xml
@@ -5,4 +5,22 @@
         https://symfony.com/schema/routing/routing-1.0.xsd">
 
     <import resource="../../**/Controller/**/*Controller.php" type="attribute" />
+
+    <route id="api.PaynlPayment.finalize-transaction"
+           path="/api/paynl/payment/finalize-transaction"
+           methods="GET">
+        <default key="_controller">PaynlPayment\Shopware6\Controller\Api\Payment\PaymentController::finalizeTransaction</default>
+        <default key="_routeScope"><list><string>api</string></list></default>
+        <default key="auth_required"><bool>false</bool></default>
+        <default key="auth_enabled"><bool>false</bool></default>
+    </route>
+
+    <route id="api.PaynlPayment.notify"
+           path="/api/paynl/notify"
+           methods="GET|POST">
+        <default key="_controller">PaynlPayment\Shopware6\Controller\Api\Notification\NotificationController::notify</default>
+        <default key="_routeScope"><list><string>api</string></list></default>
+        <default key="auth_required"><bool>false</bool></default>
+        <default key="auth_enabled"><bool>false</bool></default>
+    </route>
 </routes>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -83,6 +83,31 @@
             <argument type="service" id="PaynlPayment\Shopware6\Repository\Language\LanguageRepository"/>
         </service>
 
+        <!-- Router (headless support) -->
+        <service id="PaynlPayment\Shopware6\Service\Router\RoutingDetector">
+            <argument type="service" id="request_stack"/>
+        </service>
+
+        <service id="PaynlPayment\Shopware6\Service\Router\PaymentUrlBuilder">
+            <argument type="service" id="router"/>
+            <argument type="service" id="PaynlPayment\Shopware6\Service\Router\RoutingDetector"/>
+            <argument>%env(default::APP_URL)%</argument>
+        </service>
+
+        <!-- Payment finalize (shared storefront + API) -->
+        <service id="PaynlPayment\Shopware6\Service\Payment\PaymentFinalizeFacade">
+            <argument type="service" id="Shopware\Core\Checkout\Payment\Controller\PaymentController"/>
+            <argument type="service" id="paynl_payments.logger"/>
+            <argument type="service" id="PaynlPayment\Shopware6\Repository\OrderTransaction\OrderTransactionRepository"/>
+            <argument type="service" id="PaynlPayment\Shopware6\Repository\PaynlTransactions\PaynlTransactionsRepository"/>
+            <argument type="service" id="router"/>
+        </service>
+
+        <!-- Notify callback (shared storefront + API) -->
+        <service id="PaynlPayment\Shopware6\Service\Notification\NotificationFacade">
+            <argument type="service" id="PaynlPayment\Shopware6\Helper\ProcessingHelper"/>
+        </service>
+
         <!--Components-->
         <service id="PaynlPayment\Shopware6\Components\ConfigReader\ConfigReader">
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
@@ -156,6 +181,7 @@
             <argument type="service" id="translator"/>
             <argument type="service" id="request_stack"/>
             <argument>%kernel.shopware_version%</argument>
+            <argument type="service" id="PaynlPayment\Shopware6\Service\Router\PaymentUrlBuilder"/>
         </service>
 
         <service id="PaynlPayment\Shopware6\Components\Payment\FinalizePaymentAction" public="true">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -83,7 +83,6 @@
             <argument type="service" id="PaynlPayment\Shopware6\Repository\Language\LanguageRepository"/>
         </service>
 
-        <!-- Router (headless support) -->
         <service id="PaynlPayment\Shopware6\Service\Router\RoutingDetector">
             <argument type="service" id="request_stack"/>
         </service>
@@ -94,7 +93,6 @@
             <argument>%env(default::APP_URL)%</argument>
         </service>
 
-        <!-- Payment finalize (shared storefront + API) -->
         <service id="PaynlPayment\Shopware6\Service\Payment\PaymentFinalizeFacade">
             <argument type="service" id="Shopware\Core\Checkout\Payment\Controller\PaymentController"/>
             <argument type="service" id="paynl_payments.logger"/>
@@ -103,7 +101,6 @@
             <argument type="service" id="router"/>
         </service>
 
-        <!-- Notify callback (shared storefront + API) -->
         <service id="PaynlPayment\Shopware6\Service\Notification\NotificationFacade">
             <argument type="service" id="PaynlPayment\Shopware6\Helper\ProcessingHelper"/>
         </service>
@@ -171,17 +168,16 @@
         </service>
 
         <service id="PaynlPayment\Shopware6\Components\Payment\InitiatePaymentAction" public="true">
-            <argument type="service" id="Symfony\Component\Routing\Generator\UrlGeneratorInterface"/>
             <argument type="service" id="PaynlPayment\Shopware6\Components\Api"/>
             <argument type="service" id="paynl_payments.logger"/>
             <argument type="service" id="PaynlPayment\Shopware6\Service\PaymentMethod\PaymentMethodTerminalService"/>
             <argument type="service" id="PaynlPayment\Shopware6\Helper\ProcessingHelper"/>
             <argument type="service" id="PaynlPayment\Shopware6\Helper\PluginHelper"/>
             <argument type="service" id="PaynlPayment\Shopware6\Helper\RequestDataBagHelper"/>
+            <argument type="service" id="PaynlPayment\Shopware6\Service\Router\PaymentUrlBuilder"/>
             <argument type="service" id="translator"/>
             <argument type="service" id="request_stack"/>
             <argument>%kernel.shopware_version%</argument>
-            <argument type="service" id="PaynlPayment\Shopware6\Service\Router\PaymentUrlBuilder"/>
         </service>
 
         <service id="PaynlPayment\Shopware6\Components\Payment\FinalizePaymentAction" public="true">

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -12,7 +12,7 @@
         </service>
 
         <service id="PaynlPayment\Shopware6\Controller\Storefront\Notification\NotificationController" public="true">
-            <argument type="service" id="PaynlPayment\Shopware6\Helper\ProcessingHelper"/>
+            <argument type="service" id="PaynlPayment\Shopware6\Service\Notification\NotificationFacade"/>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>
@@ -57,10 +57,23 @@
         </service>
 
         <service id="PaynlPayment\Shopware6\Controller\Storefront\Payment\PaymentController" public="true">
-            <argument type="service" id="Shopware\Core\Checkout\Payment\Controller\PaymentController"/>
-            <argument type="service" id="paynl_payments.logger"/>
             <argument type="service" id="PaynlPayment\Shopware6\Repository\OrderTransaction\OrderTransactionRepository"/>
-            <argument type="service" id="PaynlPayment\Shopware6\Repository\PaynlTransactions\PaynlTransactionsRepository"/>
+            <argument type="service" id="PaynlPayment\Shopware6\Service\Payment\PaymentFinalizeFacade"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+
+        <!-- API Controllers (headless) -->
+        <service id="PaynlPayment\Shopware6\Controller\Api\Notification\NotificationController" public="true">
+            <argument type="service" id="PaynlPayment\Shopware6\Service\Notification\NotificationFacade"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+
+        <service id="PaynlPayment\Shopware6\Controller\Api\Payment\PaymentController" public="true">
+            <argument type="service" id="PaynlPayment\Shopware6\Service\Payment\PaymentFinalizeFacade"/>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -64,7 +64,6 @@
             </call>
         </service>
 
-        <!-- API Controllers (headless) -->
         <service id="PaynlPayment\Shopware6\Controller\Api\Notification\NotificationController" public="true">
             <argument type="service" id="PaynlPayment\Shopware6\Service\Notification\NotificationFacade"/>
             <call method="setContainer">

--- a/src/Service/Notification/NotificationFacade.php
+++ b/src/Service/Notification/NotificationFacade.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PaynlPayment\Shopware6\Service\Notification;
+
+use PaynlPayment\Shopware6\Helper\ProcessingHelper;
+use Symfony\Component\HttpFoundation\Request;
+
+class NotificationFacade
+{
+    private const REQUEST_ORDER_ID = 'orderId';
+    private const REQUEST_OBJECT = 'object';
+    private const REQUEST_STATUS = 'status';
+    private const REQUEST_ACTION = 'action';
+    private const PENDING_ACTION = 'pending';
+    private const PENDING_RESPONSE = 'TRUE| Pending payment';
+
+    private ProcessingHelper $processingHelper;
+
+    public function __construct(ProcessingHelper $processingHelper)
+    {
+        $this->processingHelper = $processingHelper;
+    }
+
+    /**
+     * Handles incoming PAY. notify callback and returns the response body.
+     */
+    public function onNotify(Request $request): string
+    {
+        $transactionId = $this->getTransactionIdFromRequest($request);
+        $action = $this->getActionFromRequest($request);
+
+        if ($action === self::PENDING_ACTION) {
+            return self::PENDING_RESPONSE;
+        }
+
+        return $this->processingHelper->processNotify($transactionId);
+    }
+
+    private function getTransactionIdFromRequest(Request $request): string
+    {
+        $transactionId = $request->get('order_id', '');
+
+        if ($transactionId !== '') {
+            return (string) $transactionId;
+        }
+
+        $notifyObject = $request->get(self::REQUEST_OBJECT, []);
+
+        return (string) ($notifyObject[self::REQUEST_ORDER_ID] ?? '');
+    }
+
+    private function getActionFromRequest(Request $request): string
+    {
+        $action = $request->get(self::REQUEST_ACTION, '');
+
+        if ($action !== '') {
+            return strtolower((string) $action);
+        }
+
+        $notifyObject = $request->get(self::REQUEST_OBJECT, []);
+        $status = $notifyObject[self::REQUEST_STATUS] ?? [];
+
+        return strtolower((string) ($status[self::REQUEST_ACTION] ?? ''));
+    }
+}

--- a/src/Service/Payment/FinalizeResult.php
+++ b/src/Service/Payment/FinalizeResult.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PaynlPayment\Shopware6\Service\Payment;
+
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+class FinalizeResult
+{
+    private RedirectResponse $response;
+
+    private ?OrderTransactionEntity $orderTransaction;
+
+    public function __construct(RedirectResponse $response, ?OrderTransactionEntity $orderTransaction = null)
+    {
+        $this->response = $response;
+        $this->orderTransaction = $orderTransaction;
+    }
+
+    public function getResponse(): RedirectResponse
+    {
+        return $this->response;
+    }
+
+    public function getOrderTransaction(): ?OrderTransactionEntity
+    {
+        return $this->orderTransaction;
+    }
+}

--- a/src/Service/Payment/PaymentFinalizeFacade.php
+++ b/src/Service/Payment/PaymentFinalizeFacade.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PaynlPayment\Shopware6\Service\Payment;
+
+use PaynlPayment\Shopware6\Entity\PaynlTransactionEntity;
+use PaynlPayment\Shopware6\Exceptions\PaynlTransactionException;
+use PaynlPayment\Shopware6\Repository\OrderTransaction\OrderTransactionRepositoryInterface;
+use PaynlPayment\Shopware6\Repository\PaynlTransactions\PaynlTransactionsRepositoryInterface;
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
+use Shopware\Core\Checkout\Payment\Controller\PaymentController as ShopwarePaymentController;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\RouterInterface;
+
+class PaymentFinalizeFacade
+{
+    private const PAY_CUSTOM_FIELD = 'paynl';
+    private const TRANSACTION_FINISH_URL = 'transactionFinishUrl';
+
+    private ShopwarePaymentController $paymentController;
+
+    private LoggerInterface $logger;
+
+    private OrderTransactionRepositoryInterface $orderTransactionRepository;
+
+    private PaynlTransactionsRepositoryInterface $paynlTransactionRepository;
+
+    private RouterInterface $router;
+
+    public function __construct(
+        ShopwarePaymentController $paymentController,
+        LoggerInterface $logger,
+        OrderTransactionRepositoryInterface $orderTransactionRepository,
+        PaynlTransactionsRepositoryInterface $paynlTransactionRepository,
+        RouterInterface $router
+    ) {
+        $this->paymentController = $paymentController;
+        $this->logger = $logger;
+        $this->orderTransactionRepository = $orderTransactionRepository;
+        $this->paynlTransactionRepository = $paynlTransactionRepository;
+        $this->router = $router;
+    }
+
+    public function finalizeTransaction(Request $request, Context $context): FinalizeResult
+    {
+        $payOrderId = (string) $request->query->get('id');
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('paynlTransactionId', $payOrderId));
+        $criteria->addAssociation('order');
+        $criteria->addAssociation('orderTransaction.stateMachineState');
+        $criteria->addAssociation('orderTransaction.order');
+
+        /** @var PaynlTransactionEntity|null $payTransaction */
+        $payTransaction = $this->paynlTransactionRepository->search($criteria, $context)->first();
+
+        if ($payTransaction === null) {
+            throw PaynlTransactionException::notFoundByPayTransactionError($payOrderId);
+        }
+
+        $orderTransaction = $payTransaction->getOrderTransaction();
+        if ($orderTransaction === null) {
+            throw PaynlTransactionException::notFoundByPayTransactionError($payOrderId);
+        }
+
+        $order = $orderTransaction->getOrder();
+        if ($order === null) {
+            throw PaynlTransactionException::notFoundByPayTransactionError($orderTransaction->getId());
+        }
+
+        try {
+            $response = $this->paymentController->finalizeTransaction($request);
+            if ($response instanceof RedirectResponse) {
+                return new FinalizeResult($response, $orderTransaction);
+            }
+        } catch (HttpException $e) {
+            $this->logger->error('{message}. Redirecting to confirm page.', [
+                'message' => $e->getMessage(),
+                'error' => $e,
+            ]);
+        }
+
+        $finishUrl = $this->getOrderTransactionFinishUrl($orderTransaction);
+        if ($finishUrl !== '') {
+            return new FinalizeResult(new RedirectResponse($finishUrl), $orderTransaction);
+        }
+
+        $redirectUrl = $this->router->generate(
+            'frontend.checkout.finish.page',
+            ['orderId' => $order->getId()],
+            RouterInterface::ABSOLUTE_URL
+        );
+
+        return new FinalizeResult(new RedirectResponse($redirectUrl), $orderTransaction);
+    }
+
+    private function getOrderTransactionFinishUrl(OrderTransactionEntity $orderTransaction): string
+    {
+        $customFields = $orderTransaction->getCustomFields() ?? [];
+        $paynl = $customFields[self::PAY_CUSTOM_FIELD] ?? [];
+
+        return (string) ($paynl[self::TRANSACTION_FINISH_URL] ?? '');
+    }
+}

--- a/src/Service/Router/PaymentUrlBuilder.php
+++ b/src/Service/Router/PaymentUrlBuilder.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PaynlPayment\Shopware6\Service\Router;
+
+use Symfony\Component\Routing\RouterInterface;
+
+class PaymentUrlBuilder
+{
+    private const ROUTE_PARAM_PAYMENT_TOKEN = '_sw_payment_token';
+
+    private RouterInterface $router;
+
+    private RoutingDetector $routingDetector;
+
+    private ?string $envAppUrl;
+
+    public function __construct(
+        RouterInterface $router,
+        RoutingDetector $routingDetector,
+        ?string $envAppUrl = null
+    ) {
+        $this->router = $router;
+        $this->routingDetector = $routingDetector;
+        $this->envAppUrl = $envAppUrl ?? '';
+    }
+
+    public function buildReturnUrl(string $paymentToken): string
+    {
+        $params = [self::ROUTE_PARAM_PAYMENT_TOKEN => $paymentToken];
+
+        if ($this->routingDetector->isStoreApiRoute()) {
+            $url = $this->router->generate(
+                'api.PaynlPayment.finalize-transaction',
+                $params,
+                RouterInterface::ABSOLUTE_URL
+            );
+
+            return $this->applyAdminDomain($url);
+        }
+
+        return (string) $this->router->generate(
+            'frontend.PaynlPayment.finalize-transaction',
+            $params,
+            RouterInterface::ABSOLUTE_URL
+        );
+    }
+
+    public function buildExchangeUrl(): string
+    {
+        if ($this->routingDetector->isStoreApiRoute()) {
+            $url = $this->router->generate(
+                'api.PaynlPayment.notify',
+                [],
+                RouterInterface::ABSOLUTE_URL
+            );
+
+            return $this->applyAdminDomain($url);
+        }
+
+        return (string) $this->router->generate(
+            'frontend.PaynlPayment.notify',
+            [],
+            RouterInterface::ABSOLUTE_URL
+        );
+    }
+
+    private function applyAdminDomain(string $url): string
+    {
+        $adminDomain = trim((string) $this->envAppUrl);
+        $adminDomain = str_replace(['http://', 'https://'], '', $adminDomain);
+
+        if ($adminDomain === '' || $adminDomain === 'localhost') {
+            return $url;
+        }
+
+        $components = parse_url($url);
+        $host = (is_array($components) && isset($components['host'])) ? (string) $components['host'] : '';
+
+        return str_replace($host, $adminDomain, $url);
+    }
+}

--- a/src/Service/Router/RoutingDetector.php
+++ b/src/Service/Router/RoutingDetector.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PaynlPayment\Shopware6\Service\Router;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class RoutingDetector
+{
+    private RequestStack $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    public function isAdminApiRoute(): bool
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if ($request === null) {
+            return false;
+        }
+
+        return strpos($request->getPathInfo(), '/api/paynl/') !== false;
+    }
+
+    public function isStoreApiRoute(): bool
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if ($request === null) {
+            return false;
+        }
+
+        return strpos($request->getPathInfo(), '/store-api') === 0;
+    }
+
+    public function isStorefrontRoute(): bool
+    {
+        return !$this->isAdminApiRoute() && !$this->isStoreApiRoute();
+    }
+}


### PR DESCRIPTION
- Add RoutingDetector for path-based context (store-api vs storefront)
- Add PaymentUrlBuilder for context-aware return and exchange URLs
- Add API routes: api.PaynlPayment.finalize-transaction, api.PaynlPayment.notify
- Add API controllers (Notify + Payment) as thin wrappers reusing existing logic
- Add PaymentFinalizeFacade + FinalizeResult for shared finalize flow (storefront + API)
- Update InitiatePaymentAction to use PaymentUrlBuilder; storefront keeps current behaviour
- Optional APP_URL domain override for API URLs (default::APP_URL)